### PR TITLE
[algos/qtopt] Make iterator called only once

### DIFF
--- a/example/run_qtopt.py
+++ b/example/run_qtopt.py
@@ -162,7 +162,7 @@ while args.max_epis > total_epi:
 
         result_dict = qtopt.train(
             off_traj, qf, lagged_qf, targ_qf1, targ_qf2,
-            optim_qf, step, args.batch_size,
+            optim_qf, epoch, args.batch_size,
             args.tau, args.gamma, loss_type=args.loss_type
         )
 
@@ -181,7 +181,7 @@ while args.max_epis > total_epi:
     rewards = [np.sum(epi['rews']) for epi in epis]
     mean_rew = np.mean(rewards)
     logger.record_results(args.log, result_dict, score_file,
-                          total_epi, epoch, total_step,
+                          total_epi, step, total_step,
                           rewards,
                           plot_title=args.env_name)
 

--- a/example/run_qtopt.py
+++ b/example/run_qtopt.py
@@ -152,6 +152,7 @@ while args.max_epis > total_epi:
         total_epi += on_traj.num_epi
         step = on_traj.num_step
         total_step += step
+        epoch = step
 
         if args.data_parallel:
             qf.dp_run = True
@@ -171,7 +172,7 @@ while args.max_epis > total_epi:
             targ_qf1.dp_run = False
             targ_qf2.dp_run = False
 
-    total_grad_step += result_dict['grad_step']
+    total_grad_step += epoch
     if total_grad_step >= args.lag * num_update_lagged:
         logger.log('Updated lagged qf!!')
         lagged_qf_net.load_state_dict(qf_net.state_dict())
@@ -180,7 +181,7 @@ while args.max_epis > total_epi:
     rewards = [np.sum(epi['rews']) for epi in epis]
     mean_rew = np.mean(rewards)
     logger.record_results(args.log, result_dict, score_file,
-                          total_epi, step, total_step,
+                          total_epi, epoch, total_step,
                           rewards,
                           plot_title=args.env_name)
 

--- a/machina/algos/qtopt.py
+++ b/machina/algos/qtopt.py
@@ -66,4 +66,4 @@ def train(traj,
 
         qf_losses.append(qf_bellman_loss.detach().cpu().numpy())
     logger.log("Optimization finished!")
-    return {'QfLoss': qf_losses, 'grad_step': epoch}
+    return {'QfLoss': qf_losses}

--- a/machina/algos/qtopt.py
+++ b/machina/algos/qtopt.py
@@ -51,8 +51,7 @@ def train(traj,
     logger.log("Optimizing...")
 
     iterator = traj.random_batch(batch_size, epoch)
-    grad_step = len(list(iterator))
-    for batch in traj.random_batch(batch_size, epoch):
+    for batch in iterator:
         qf_bellman_loss = lf.clipped_double_bellman(
             qf, targ_qf1, targ_qf2, batch, gamma, loss_type=loss_type)
         optim_qf.zero_grad()
@@ -67,4 +66,4 @@ def train(traj,
 
         qf_losses.append(qf_bellman_loss.detach().cpu().numpy())
     logger.log("Optimization finished!")
-    return {'QfLoss': qf_losses, 'grad_step': grad_step}
+    return {'QfLoss': qf_losses, 'grad_step': epoch}


### PR DESCRIPTION
In current qtopt, `iterator(traj.random_batch(batch_size, epoch))` is evaluated twice. 
This PR makes it call only once.