### PR TITLE
Modified distributed adamw's local_rank and world_size arguments

### DIFF
--- a/machina/optims/distributed_adamw.py
+++ b/machina/optims/distributed_adamw.py
@@ -18,13 +18,22 @@ class DistributedAdamW(Optimizer):
         eps (float, optional): term added to the denominator to improve
             numerical stability (default: 1e-8)
         weight_decay (float, optional): weight decay (not L2 penalty) (default: 0)
+        local_rank (int, optional): if not given, automatically set
+            dist.get_rank()
+        world_size (int, optional): if not given, automatically set
+            dist.get_world_size()
     """
 
-    def __init__(self, params, local_rank, world_size, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
+    def __init__(self, params, local_rank=None, world_size=None,
+                 lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
                  weight_decay=0):
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay)
         super(DistributedAdamW, self).__init__(params, defaults)
+        if local_rank is None:
+            local_rank = dist.get_rank()
+        if world_size is None:
+            world_size = dist.get_world_size()
         self.local_rank = local_rank
         self.world_size = world_size
 

--- a/tests/optims/distributed_adamw_test.py
+++ b/tests/optims/distributed_adamw_test.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.multiprocessing import Process
+import torch.nn as nn
+
+from machina.optims import DistributedAdamW
+
+
+def init_processes(rank, world_size,
+                   function, backend='tcp'):
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '29500'
+    dist.init_process_group(backend, rank=rank,
+                            world_size=world_size)
+    function(rank, world_size)
+
+
+class TestDistributedAdamW(unittest.TestCase):
+
+    def test_step(self):
+
+        def _run(rank, world_size):
+            model = nn.Linear(10, 1)
+            optimizer = DistributedAdamW(
+                model.parameters())
+
+            optimizer.zero_grad()
+            loss = model(torch.ones(10).float())
+            loss.backward()
+            optimizer.step()
+
+        processes = []
+        world_size = 4
+        for rank in range(world_size):
+            p = Process(target=init_processes,
+                        args=(rank,
+                              world_size,
+                              _run))
+            p.start()
+            processes.append(p)
+        for p in processes:
+            p.join()

--- a/tests/optims/distributed_sgd_test.py
+++ b/tests/optims/distributed_sgd_test.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from torch.multiprocessing import Process
+import torch.nn as nn
+
+from machina.optims import DistributedSGD
+
+
+def init_processes(rank, world_size,
+                   function, backend='tcp'):
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '29500'
+    dist.init_process_group(backend, rank=rank,
+                            world_size=world_size)
+    function(rank, world_size)
+
+
+class TestDistributedSGD(unittest.TestCase):
+
+    def test_step(self):
+
+        def _run(rank, world_size):
+            model = nn.Linear(10, 1)
+            optimizer = DistributedSGD(
+                model.parameters())
+
+            optimizer.zero_grad()
+            loss = model(torch.ones(10).float())
+            loss.backward()
+            optimizer.step()
+
+        processes = []
+        world_size = 4
+        for rank in range(world_size):
+            p = Process(target=init_processes,
+                        args=(rank,
+                              world_size,
+                              _run))
+            p.start()
+            processes.append(p)
+        for p in processes:
+            p.join()


### PR DESCRIPTION
This PR modified the arguments of distributed adamw.
`local_rank` and `world_size` 's default value is None and automatically set  `dist.get_rank()` and `dist.get_world_size()` values.
I also add the test code of `DistributedAdamW` and `DistributedSGD`.