### PR TITLE
Gym requirement is outdated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'joblib>=0.11',
     'cloudpickle',
     'redis',
-    'gym==0.10.5',
+    'gym>=0.10.5',
     'numpy>=1.13.3',
     'terminaltables',
     'pandas',


### PR DESCRIPTION
Do you guys really need the version 0.10.5 of OpenAI Gym? I propose using a minimum version requirement instead. Here's the [Gym release page](https://github.com/openai/gym/releases) just in case.