### PR TITLE
Introduce flake8, format files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E266, F401, F841, W503, W504, E704, E741
+max-line-length = 140
+exclude = ./machina/logger.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ install:
     - pip install --upgrade pip setuptools wheel psutil pytest
     - pip install --default-timeout=2000 -q -e .
     - pip list
-    - pip install autopep8
+    - pip install autopep8 flake8
     - curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1hzRxBhnkQA3lWLzTFdVuJ0t5Cj1IvVIU" > /dev/null
     - CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
     - curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1hzRxBhnkQA3lWLzTFdVuJ0t5Cj1IvVIU" -o data/expert_epis/Pendulum-v0_2epis.pkl
 script:
-    - autopep8 -r . --diff | tee check_autopep8
-    - test ! -s check_autopep8
+    - autopep8 -r . --diff --exit-code
+    - flake8 .
     - pytest -x tests
 sudo: required

--- a/example/make_expert_epis.py
+++ b/example/make_expert_epis.py
@@ -108,7 +108,7 @@ else:
         raise ValueError('Only Box, Discrete, and MultiDiscrete are supported')
 
 
-sampler = EpiSampler(env, pol, num_parallel=args.num_parallel,  seed=args.seed)
+sampler = EpiSampler(env, pol, num_parallel=args.num_parallel, seed=args.seed)
 
 with open(os.path.join(args.pol_dir, args.pol_fname), 'rb') as f:
     pol.load_state_dict(torch.load(

--- a/example/quickstart/simple_net.py
+++ b/example/quickstart/simple_net.py
@@ -45,7 +45,7 @@ class PolNet(nn.Module):
             self.mean_layer = nn.Linear(h2, action_space.shape[0])
             if not self.deterministic:
                 self.log_std_param = nn.Parameter(
-                    torch.randn(action_space.shape[0])*1e-10 - 1)
+                    torch.randn(action_space.shape[0]) * 1e-10 - 1)
             self.mean_layer.apply(mini_weight_init)
         else:
             if self.multi:
@@ -125,7 +125,7 @@ class PolNetLSTM(nn.Module):
         if not self.discrete:
             self.mean_layer = nn.Linear(self.cell_size, action_space.shape[0])
             self.log_std_param = nn.Parameter(
-                torch.randn(action_space.shape[0])*1e-10 - 1)
+                torch.randn(action_space.shape[0]) * 1e-10 - 1)
 
             self.mean_layer.apply(mini_weight_init)
         else:
@@ -163,7 +163,8 @@ class PolNetLSTM(nn.Module):
             return means, log_std, hs
         else:
             if self.multi:
-                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2) for ol in self.output_layers], dim=-2), hs
+                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2)
+                                  for ol in self.output_layers], dim=-2), hs
             else:
                 return torch.softmax(self.output_layer(hiddens), dim=-1), hs
 

--- a/example/run_airl.py
+++ b/example/run_airl.py
@@ -87,8 +87,15 @@ parser.add_argument('--discrim_h1', type=int, default=100,
 parser.add_argument('--discrim_h2', type=int, default=100,
                     help='Hidden size of layer2 of discriminator.')
 
-parser.add_argument('--rl_type', type=str,
-                    choices=['trpo', 'ppo_clip', 'ppo_kl'], default='trpo', help='Choice for Reinforcement Learning algorithms.')
+parser.add_argument(
+    '--rl_type',
+    type=str,
+    choices=[
+        'trpo',
+        'ppo_clip',
+        'ppo_kl'],
+    default='trpo',
+    help='Choice for Reinforcement Learning algorithms.')
 
 parser.add_argument('--clip_param', type=float, default=0.2,
                     help='Value of clipping liklihood ratio.')

--- a/example/run_ddpg.py
+++ b/example/run_ddpg.py
@@ -158,20 +158,20 @@ while args.max_epis > total_epi:
         torch.save(pol.state_dict(), os.path.join(
             args.log, 'models', 'pol_max.pkl'))
         torch.save(qf.state_dict(), os.path.join(
-            args.log, 'models',  'qf_max.pkl'))
+            args.log, 'models', 'qf_max.pkl'))
         torch.save(optim_pol.state_dict(), os.path.join(
-            args.log, 'models',  'optim_pol_max.pkl'))
+            args.log, 'models', 'optim_pol_max.pkl'))
         torch.save(optim_qf.state_dict(), os.path.join(
-            args.log, 'models',  'optim_qf_max.pkl'))
+            args.log, 'models', 'optim_qf_max.pkl'))
         max_rew = mean_rew
 
     torch.save(pol.state_dict(), os.path.join(
-        args.log, 'models',  'pol_last.pkl'))
+        args.log, 'models', 'pol_last.pkl'))
     torch.save(qf.state_dict(), os.path.join(
         args.log, 'models', 'qf_last.pkl'))
     torch.save(optim_pol.state_dict(), os.path.join(
-        args.log, 'models',  'optim_pol_last.pkl'))
+        args.log, 'models', 'optim_pol_last.pkl'))
     torch.save(optim_qf.state_dict(), os.path.join(
-        args.log, 'models',  'optim_qf_last.pkl'))
+        args.log, 'models', 'optim_qf_last.pkl'))
     del on_traj
 del sampler

--- a/example/run_diayn.py
+++ b/example/run_diayn.py
@@ -6,7 +6,6 @@ https://arxiv.org/abs/1802.06070
 
 import os
 import gym
-import torch
 import argparse
 import numpy as np
 import pybullet_envs
@@ -22,7 +21,7 @@ from machina.utils import measure
 from machina.algos import diayn_sac, diayn
 from machina.pols import GaussianPol
 from machina.samplers import EpiSampler
-from machina.utils import set_device, measure
+from machina.utils import set_device
 from machina.traj import epi_functional as ef
 from machina.vfuncs import DeterministicSAVfunc, DeterministicSVfunc
 from simple_net import PolNet, QNet, DiaynDiscrimNet
@@ -77,7 +76,7 @@ f_dim = 9  # dimension of feature space
 '''
 
 
-def discrim_f(x): return x[:, 0:2]+x[:, 2:4]
+def discrim_f(x): return x[:, 0:2] + x[:, 2:4]
 
 
 f_dim = 2
@@ -115,7 +114,7 @@ targ_qfs = [targ_qf1, targ_qf2]
 
 log_alpha = nn.Parameter(torch.ones((), device=device))
 
-high = np.array([np.finfo(np.float32).max]*f_dim)
+high = np.array([np.finfo(np.float32).max] * f_dim)
 f_space = gym.spaces.Box(-high, high, dtype=np.float32)
 discrim_net = DiaynDiscrimNet(
     f_space, skill_space, h_size=args.discrim_h_size, discrim_f=discrim_f).to(device)
@@ -138,7 +137,7 @@ sampler = EpiSampler(
 
 if not os.path.exists(args.log):
     os.makedirs(args.log)
-    os.makedirs(args.log+'/models')
+    os.makedirs(args.log + '/models')
 score_file = os.path.join(args.log, 'progress.csv')
 logger.add_tabular_output(score_file)
 logger.add_tensorboard_output(args.log)
@@ -174,7 +173,7 @@ while args.max_episodes > total_epi:
         step = on_traj.num_step
         total_step += step
         log_alpha = nn.Parameter(
-            np.log(0.1)*torch.ones((), device=device))  # fix alpha
+            np.log(0.1) * torch.ones((), device=device))  # fix alpha
 
         result_dict = diayn_sac.train(
             off_traj,
@@ -200,23 +199,23 @@ while args.max_episodes > total_epi:
     steps_as = str(int(
         int(total_step / args.steps_per_save_models + 1) * args.steps_per_save_models))
     if 'prev_as' in locals():
-        if not prev_as == steps_as:
+        if not prev_as == steps_as:  # noqa
             torch.save(pol.state_dict(), os.path.join(
-                args.log, 'models', 'pol_'+steps_as+'.pkl'))
+                args.log, 'models', 'pol_' + steps_as + '.pkl'))
             torch.save(qf1.state_dict(), os.path.join(
-                args.log, 'models', 'qf1_'+steps_as+'.pkl'))
+                args.log, 'models', 'qf1_' + steps_as + '.pkl'))
             torch.save(qf2.state_dict(), os.path.join(
-                args.log, 'models', 'qf2_'+steps_as+'.pkl'))
+                args.log, 'models', 'qf2_' + steps_as + '.pkl'))
             torch.save(discrim.state_dict(), os.path.join(
-                args.log, 'models', 'discrim_'+steps_as+'.pkl'))
+                args.log, 'models', 'discrim_' + steps_as + '.pkl'))
             torch.save(optim_pol.state_dict(), os.path.join(
-                args.log, 'models', 'optim_pol_'+steps_as+'.pkl'))
+                args.log, 'models', 'optim_pol_' + steps_as + '.pkl'))
             torch.save(optim_qf1.state_dict(), os.path.join(
-                args.log, 'models', 'optim_qf1_'+steps_as+'.pkl'))
+                args.log, 'models', 'optim_qf1_' + steps_as + '.pkl'))
             torch.save(optim_qf2.state_dict(), os.path.join(
-                args.log, 'models', 'optim_qf2_'+steps_as+'.pkl'))
+                args.log, 'models', 'optim_qf2_' + steps_as + '.pkl'))
             torch.save(optim_discrim.state_dict(), os.path.join(
-                args.log, 'models', 'optim_discrim_'+steps_as+'.pkl'))
+                args.log, 'models', 'optim_discrim_' + steps_as + '.pkl'))
     prev_as = str(int(
         int(total_step / args.steps_per_save_models + 1) * args.steps_per_save_models))
     del on_traj

--- a/example/run_gail.py
+++ b/example/run_gail.py
@@ -203,12 +203,21 @@ while args.max_epis > total_epi:
         agent_traj.register_epis()
 
         if args.rl_type == 'trpo':
-            result_dict = gail.train(agent_traj, expert_traj, pol, vf, discrim, optim_vf, optim_discrim,
-                                     rl_type=args.rl_type,
-                                     epoch=args.epoch_per_iter,
-                                     batch_size=args.batch_size if not args.rnn else args.rnn_batch_size, discrim_batch_size=args.discrim_batch_size,
-                                     discrim_step=args.discrim_step,
-                                     pol_ent_beta=args.pol_ent_beta, discrim_ent_beta=args.discrim_ent_beta)
+            result_dict = gail.train(
+                agent_traj,
+                expert_traj,
+                pol,
+                vf,
+                discrim,
+                optim_vf,
+                optim_discrim,
+                rl_type=args.rl_type,
+                epoch=args.epoch_per_iter,
+                batch_size=args.batch_size if not args.rnn else args.rnn_batch_size,
+                discrim_batch_size=args.discrim_batch_size,
+                discrim_step=args.discrim_step,
+                pol_ent_beta=args.pol_ent_beta,
+                discrim_ent_beta=args.discrim_ent_beta)
         elif args.rl_type == 'ppo_clip':
             result_dict = gail.train(agent_traj, expert_traj, pol, vf, discrim, optim_vf, optim_discrim,
                                      rl_type=args.rl_type,

--- a/example/run_mixed_env.py
+++ b/example/run_mixed_env.py
@@ -161,8 +161,16 @@ while args.max_epis > total_epi:
 
         traj1.add_traj(traj2)
 
-        result_dict = ppo_clip.train(traj=traj1, pol=pol, vf=vf, clip_param=args.clip_param,
-                                     optim_pol=optim_pol, optim_vf=optim_vf, epoch=args.epoch_per_iter, batch_size=args.batch_size if not args.rnn else args.rnn_batch_size, max_grad_norm=args.max_grad_norm)
+        result_dict = ppo_clip.train(
+            traj=traj1,
+            pol=pol,
+            vf=vf,
+            clip_param=args.clip_param,
+            optim_pol=optim_pol,
+            optim_vf=optim_vf,
+            epoch=args.epoch_per_iter,
+            batch_size=args.batch_size if not args.rnn else args.rnn_batch_size,
+            max_grad_norm=args.max_grad_norm)
 
     total_epi += traj1.num_epi
     step = traj1.num_step

--- a/example/run_mpc.py
+++ b/example/run_mpc.py
@@ -41,7 +41,7 @@ def rew_func(next_obs, acs, mean_obs=0., std_obs=1., mean_acs=0., std_acs=1.):
     acs = acs * std_acs + mean_acs
     # Pendulum
     rews = -(torch.acos(next_obs[:, 0].clamp(min=-1, max=1))**2 +
-             0.1*(next_obs[:, 2].clamp(min=-8, max=8)**2) + 0.001 * acs.squeeze(-1)**2)
+             0.1 * (next_obs[:, 2].clamp(min=-8, max=8)**2) + 0.001 * acs.squeeze(-1)**2)
     rews = rews.squeeze(0)
 
     return rews
@@ -164,8 +164,8 @@ counter_agg_iters = 0
 max_rew = -1e+6
 while args.max_epis > total_epi:
     with measure('train model'):
-        result_dict = mpc.train_dm(
-            traj, dm, optim_dm, epoch=args.epoch_per_iter, batch_size=args.batch_size if not args.rnn else args.rnn_batch_size)
+        result_dict = mpc.train_dm(traj, dm, optim_dm, epoch=args.epoch_per_iter,
+                                   batch_size=args.batch_size if not args.rnn else args.rnn_batch_size)
     with measure('sample'):
         mpc_pol = MPCPol(observation_space, action_space, dm.net, rew_func,
                          args.n_samples, args.horizon_of_samples,

--- a/example/run_ppo.py
+++ b/example/run_ppo.py
@@ -151,11 +151,28 @@ while args.max_epis > total_epi:
         traj.register_epis()
 
         if args.ppo_type == 'clip':
-            result_dict = ppo_clip.train(traj=traj, pol=pol, vf=vf, clip_param=args.clip_param,
-                                         optim_pol=optim_pol, optim_vf=optim_vf, epoch=args.epoch_per_iter, batch_size=args.batch_size if not args.rnn else args.rnn_batch_size, max_grad_norm=args.max_grad_norm)
+            result_dict = ppo_clip.train(
+                traj=traj,
+                pol=pol,
+                vf=vf,
+                clip_param=args.clip_param,
+                optim_pol=optim_pol,
+                optim_vf=optim_vf,
+                epoch=args.epoch_per_iter,
+                batch_size=args.batch_size if not args.rnn else args.rnn_batch_size,
+                max_grad_norm=args.max_grad_norm)
         else:
-            result_dict = ppo_kl.train(traj=traj, pol=pol, vf=vf, kl_beta=kl_beta, kl_targ=args.kl_targ,
-                                       optim_pol=optim_pol, optim_vf=optim_vf, epoch=args.epoch_per_iter, batch_size=args.batch_size if not args.rnn else args.rnn_batch_size, max_grad_norm=args.max_grad_norm)
+            result_dict = ppo_kl.train(
+                traj=traj,
+                pol=pol,
+                vf=vf,
+                kl_beta=kl_beta,
+                kl_targ=args.kl_targ,
+                optim_pol=optim_pol,
+                optim_vf=optim_vf,
+                epoch=args.epoch_per_iter,
+                batch_size=args.batch_size if not args.rnn else args.rnn_batch_size,
+                max_grad_norm=args.max_grad_norm)
             kl_beta = result_dict['new_kl_beta']
 
     total_epi += traj.num_epi

--- a/example/run_ppo_distributed_ray.py
+++ b/example/run_ppo_distributed_ray.py
@@ -284,12 +284,21 @@ if __name__ == "__main__":
                         help='apex option. sync batch norm statistics.')
 
     # Ray option
-    parser.add_argument('--ray_redis_address', type=str, default=None,
-                        help='Ray cluster\'s address that this programm connect to. If not specified, start ray locally.')
-    parser.add_argument('--num_gpus', type=int, default=None,
-                        help='Number of GPUs that ray manages. Only effective when launching ray locally. default: all GPUs available.')
-    parser.add_argument('--num_cpus', type=int, default=None,
-                        help='Number of CPUs that ray manages. Only effective when launching ray locally. default: all CPUs available.')
+    parser.add_argument(
+        '--ray_redis_address',
+        type=str,
+        default=None,
+        help='Ray cluster\'s address that this programm connect to. If not specified, start ray locally.')
+    parser.add_argument(
+        '--num_gpus',
+        type=int,
+        default=None,
+        help='Number of GPUs that ray manages. Only effective when launching ray locally. default: all GPUs available.')
+    parser.add_argument(
+        '--num_cpus',
+        type=int,
+        default=None,
+        help='Number of CPUs that ray manages. Only effective when launching ray locally. default: all CPUs available.')
     parser.add_argument('--num_trainer', type=int, default=1,
                         help='Number of trainers (number of GPUs to train).')
     args = parser.parse_args()

--- a/example/run_ppo_distributed_sampler.py
+++ b/example/run_ppo_distributed_sampler.py
@@ -44,11 +44,12 @@ parser.add_argument('--num_parallel', type=int, default=4,
                     help='Number of processes to sample.')
 parser.add_argument('--cuda', type=int, default=-1, help='cuda device number.')
 
-####################  Steps  ##########################################################################################################################
+"""
+Trainig Step
 # 1. Launch redis server via `redis-server`.                                                                                                          #
 # 2. Run this script.                                                                                                                                 #
 # 3. Launch sampling nodes via `python -m machina.samplers.distributed_sampler --world_size size --rank rank --redis_host hostname --redis_port port` #
-#######################################################################################################################################################
+"""  # noqa
 
 parser.add_argument('--sampler_world_size', type=int,
                     help='number of sampling nodes.')
@@ -179,11 +180,28 @@ while args.max_epis > total_epi:
         traj = tf.sync(traj)
 
         if args.ppo_type == 'clip':
-            result_dict = ppo_clip.train(traj=traj, pol=pol, vf=vf, clip_param=args.clip_param,
-                                         optim_pol=optim_pol, optim_vf=optim_vf, epoch=args.epoch_per_iter, batch_size=args.batch_size if not args.rnn else args.rnn_batch_size, max_grad_norm=args.max_grad_norm)
+            result_dict = ppo_clip.train(
+                traj=traj,
+                pol=pol,
+                vf=vf,
+                clip_param=args.clip_param,
+                optim_pol=optim_pol,
+                optim_vf=optim_vf,
+                epoch=args.epoch_per_iter,
+                batch_size=args.batch_size if not args.rnn else args.rnn_batch_size,
+                max_grad_norm=args.max_grad_norm)
         else:
-            result_dict = ppo_kl.train(traj=traj, pol=pol, vf=vf, kl_beta=kl_beta, kl_targ=args.kl_targ,
-                                       optim_pol=optim_pol, optim_vf=optim_vf, epoch=args.epoch_per_iter, batch_size=args.batch_size if not args.rnn else args.rnn_batch_size, max_grad_norm=args.max_grad_norm)
+            result_dict = ppo_kl.train(
+                traj=traj,
+                pol=pol,
+                vf=vf,
+                kl_beta=kl_beta,
+                kl_targ=args.kl_targ,
+                optim_pol=optim_pol,
+                optim_vf=optim_vf,
+                epoch=args.epoch_per_iter,
+                batch_size=args.batch_size if not args.rnn else args.rnn_batch_size,
+                max_grad_norm=args.max_grad_norm)
             kl_beta = result_dict['new_kl_beta']
 
     total_epi += traj.num_epi

--- a/example/run_ppo_sac.py
+++ b/example/run_ppo_sac.py
@@ -147,8 +147,16 @@ while args.max_epis > total_epi:
         on_traj = ef.compute_h_masks(on_traj)
         on_traj.register_epis()
 
-        result_dict1 = ppo_clip.train(traj=on_traj, pol=pol, vf=vf, clip_param=args.clip_param,
-                                      optim_pol=optim_pol, optim_vf=optim_vf, epoch=args.epoch_per_iter, batch_size=args.batch_size, max_grad_norm=args.max_grad_norm)
+        result_dict1 = ppo_clip.train(
+            traj=on_traj,
+            pol=pol,
+            vf=vf,
+            clip_param=args.clip_param,
+            optim_pol=optim_pol,
+            optim_vf=optim_vf,
+            epoch=args.epoch_per_iter,
+            batch_size=args.batch_size,
+            max_grad_norm=args.max_grad_norm)
 
         total_epi += on_traj.num_epi
         step = on_traj.num_step

--- a/example/run_prioritized_ddpg.py
+++ b/example/run_prioritized_ddpg.py
@@ -160,20 +160,20 @@ while args.max_epis > total_epi:
         torch.save(pol.state_dict(), os.path.join(
             args.log, 'models', 'pol_max.pkl'))
         torch.save(qf.state_dict(), os.path.join(
-            args.log, 'models',  'qf_max.pkl'))
+            args.log, 'models', 'qf_max.pkl'))
         torch.save(optim_pol.state_dict(), os.path.join(
-            args.log, 'models',  'optim_pol_max.pkl'))
+            args.log, 'models', 'optim_pol_max.pkl'))
         torch.save(optim_qf.state_dict(), os.path.join(
-            args.log, 'models',  'optim_qf_max.pkl'))
+            args.log, 'models', 'optim_qf_max.pkl'))
         max_rew = mean_rew
 
     torch.save(pol.state_dict(), os.path.join(
-        args.log, 'models',  'pol_last.pkl'))
+        args.log, 'models', 'pol_last.pkl'))
     torch.save(qf.state_dict(), os.path.join(
         args.log, 'models', 'qf_last.pkl'))
     torch.save(optim_pol.state_dict(), os.path.join(
-        args.log, 'models',  'optim_pol_last.pkl'))
+        args.log, 'models', 'optim_pol_last.pkl'))
     torch.save(optim_qf.state_dict(), os.path.join(
-        args.log, 'models',  'optim_qf_last.pkl'))
+        args.log, 'models', 'optim_qf_last.pkl'))
     del on_traj
 del sampler

--- a/example/run_qtopt.py
+++ b/example/run_qtopt.py
@@ -69,8 +69,10 @@ parser.add_argument('--num_sampling', type=int, default=60,
                     help='Number of samples sampled from Gaussian in CEM.')
 parser.add_argument('--num_best_sampling', type=int, default=6,
                     help='Number of best samples used for fitting Gaussian in CEM.')
-parser.add_argument('--multivari', action='store_true',
-                    help='If true, Gaussian with diagonal covarince instead of Multivariate Gaussian matrix is used in CEM.')
+parser.add_argument(
+    '--multivari',
+    action='store_true',
+    help='If true, Gaussian with diagonal covarince instead of Multivariate Gaussian matrix is used in CEM.')
 parser.add_argument('--eps', type=float, default=0.2,
                     help='Probability of random action in epsilon-greedy policy.')
 parser.add_argument('--loss_type', type=str,
@@ -178,17 +180,17 @@ while args.max_epis > total_epi:
         torch.save(pol.state_dict(), os.path.join(
             args.log, 'models', 'pol_max.pkl'))
         torch.save(qf.state_dict(), os.path.join(
-            args.log, 'models',  'qf_max.pkl'))
+            args.log, 'models', 'qf_max.pkl'))
         torch.save(targ_qf1.state_dict(), os.path.join(
-            args.log, 'models',  'targ_qf1_max.pkl'))
+            args.log, 'models', 'targ_qf1_max.pkl'))
         torch.save(targ_qf2.state_dict(), os.path.join(
-            args.log, 'models',  'targ_qf2_max.pkl'))
+            args.log, 'models', 'targ_qf2_max.pkl'))
         torch.save(optim_qf.state_dict(), os.path.join(
-            args.log, 'models',  'optim_qf_max.pkl'))
+            args.log, 'models', 'optim_qf_max.pkl'))
         max_rew = mean_rew
 
     torch.save(pol.state_dict(), os.path.join(
-        args.log, 'models',  'pol_last.pkl'))
+        args.log, 'models', 'pol_last.pkl'))
     torch.save(qf.state_dict(), os.path.join(
         args.log, 'models', 'qf_last.pkl'))
     torch.save(targ_qf1.state_dict(), os.path.join(
@@ -196,6 +198,6 @@ while args.max_epis > total_epi:
     torch.save(targ_qf2.state_dict(), os.path.join(
         args.log, 'models', 'targ_qf2_last.pkl'))
     torch.save(optim_qf.state_dict(), os.path.join(
-        args.log, 'models',  'optim_qf_last.pkl'))
+        args.log, 'models', 'optim_qf_last.pkl'))
     del on_traj
 del sampler

--- a/example/run_r2d2_sac.py
+++ b/example/run_r2d2_sac.py
@@ -151,9 +151,9 @@ while args.max_epis > total_epi:
         on_traj = ef.compute_h_masks(on_traj)
         for i in range(len(qfs)):
             on_traj = ef.compute_hs(
-                on_traj, qfs[i], hs_name='q_hs'+str(i), input_acs=True)
+                on_traj, qfs[i], hs_name='q_hs' + str(i), input_acs=True)
             on_traj = ef.compute_hs(
-                on_traj, targ_qfs[i], hs_name='targ_q_hs'+str(i), input_acs=True)
+                on_traj, targ_qfs[i], hs_name='targ_q_hs' + str(i), input_acs=True)
         on_traj.register_epis()
 
         off_traj.add_traj(on_traj)
@@ -166,7 +166,7 @@ while args.max_epis > total_epi:
             off_traj,
             pol, qfs, targ_qfs, log_alpha,
             optim_pol, optim_qfs, optim_alpha,
-            step//50, args.rnn_batch_size, args.seq_length, args.burn_in_length,
+            step // 50, args.rnn_batch_size, args.seq_length, args.burn_in_length,
             args.tau, args.gamma, args.sampling, not args.no_reparam
         )
 

--- a/example/run_teacher_distill.py
+++ b/example/run_teacher_distill.py
@@ -191,4 +191,5 @@ while args.max_epis > total_epi:
 
     del traj
     del traj_measure
-del sampler
+del teacher_sampler
+del student_sampler

--- a/example/run_trpo.py
+++ b/example/run_trpo.py
@@ -114,8 +114,8 @@ while args.max_epis > total_epi:
         traj = ef.compute_h_masks(traj)
         traj.register_epis()
 
-        result_dict = trpo.train(
-            traj, pol, vf, optim_vf, args.epoch_per_iter, batch_size=args.batch_size if not args.rnn else args.rnn_batch_size)
+        result_dict = trpo.train(traj, pol, vf, optim_vf, args.epoch_per_iter,
+                                 batch_size=args.batch_size if not args.rnn else args.rnn_batch_size)
 
     total_epi += traj.num_epi
     step = traj.num_step

--- a/example/simple_net.py
+++ b/example/simple_net.py
@@ -45,7 +45,7 @@ class PolNet(nn.Module):
             self.mean_layer = nn.Linear(h2, action_space.shape[0])
             if not self.deterministic:
                 self.log_std_param = nn.Parameter(
-                    torch.randn(action_space.shape[0])*1e-10 - 1)
+                    torch.randn(action_space.shape[0]) * 1e-10 - 1)
             self.mean_layer.apply(mini_weight_init)
         else:
             if self.multi:
@@ -143,7 +143,7 @@ class PolNetLSTM(nn.Module):
         if not self.discrete:
             self.mean_layer = nn.Linear(self.cell_size, action_space.shape[0])
             self.log_std_param = nn.Parameter(
-                torch.randn(action_space.shape[0])*1e-10 - 1)
+                torch.randn(action_space.shape[0]) * 1e-10 - 1)
 
             self.mean_layer.apply(mini_weight_init)
         else:
@@ -181,7 +181,8 @@ class PolNetLSTM(nn.Module):
             return means, log_std, hs
         else:
             if self.multi:
-                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2) for ol in self.output_layers], dim=-2), hs
+                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2)
+                                  for ol in self.output_layers], dim=-2), hs
             else:
                 return torch.softmax(self.output_layer(hiddens), dim=-1), hs
 

--- a/example/take_movie.py
+++ b/example/take_movie.py
@@ -97,7 +97,7 @@ else:
         raise ValueError('Only Box, Discrete, and MultiDiscrete are supported')
 
 
-sampler = EpiSampler(env, pol, num_parallel=1,  seed=args.seed)
+sampler = EpiSampler(env, pol, num_parallel=1, seed=args.seed)
 
 with open(os.path.join(args.pol_dir, 'models', args.pol_fname), 'rb') as f:
     pol.load_state_dict(torch.load(

--- a/machina/algos/__init__.py
+++ b/machina/algos/__init__.py
@@ -2,7 +2,7 @@
 - This package trains :class:`Policy<machina.pols.base.BasePol>`, :class:`V function<machina.vfuncs.state_action_vfuncs.base.BaseSAVfunc>`, :class:`Q function<machina.vfuncs.state_vfuncs.base.BaseSVfunc>`, etc. by using :py:mod:`loss_functional<machina.loss_functional>`.
 - It is determined here which :py:mod:`loss_functional<machina.loss_functional>`, :py:meth:`iterater<machina.traj.traj.Traj.iterate>` are used.
 - Also, It is determined how `Policy<machina.pols.base.BasePol>`, :class:`V function<machina.vfuncs.state_action_vfuncs.base.BaseSAVfunc>`, :class:`Q function<machina.vfuncs.state_vfuncs.base.BaseSVfunc>`, etc. are updated.
-"""
+"""  # noqa
 from machina.algos import airl  # NOQA
 from machina.algos import behavior_clone  # NOQA
 from machina.algos import ddpg  # NOQA

--- a/machina/algos/airl.py
+++ b/machina/algos/airl.py
@@ -55,18 +55,24 @@ def train(agent_traj, expert_traj, pol, vf,
                 pol, batch, max_kl=max_kl, num_cg=num_cg, damping=damping, ent_beta=pol_ent_beta)
             pol_losses.append(pol_loss)
 
-        iterator = agent_traj.iterate(batch_size, epoch) if not pol.rnn else agent_traj.iterate_rnn(batch_size=batch_size,
-                                                                                                    num_epi_per_seq=num_epi_per_seq,
-                                                                                                    epoch=epoch)
+        iterator = agent_traj.iterate(
+            batch_size,
+            epoch) if not pol.rnn else agent_traj.iterate_rnn(
+            batch_size=batch_size,
+            num_epi_per_seq=num_epi_per_seq,
+            epoch=epoch)
         for batch in iterator:
             vf_loss = trpo.update_vf(vf, optim_vf, batch)
             vf_losses.append(vf_loss)
         new_kl_beta = 0
         kl_mean = 0
     elif rl_type == 'ppo_clip':
-        iterator = agent_traj.iterate(batch_size, epoch) if not pol.rnn else agent_traj.iterate_rnn(batch_size=batch_size,
-                                                                                                    num_epi_per_seq=num_epi_per_seq,
-                                                                                                    epoch=epoch)
+        iterator = agent_traj.iterate(
+            batch_size,
+            epoch) if not pol.rnn else agent_traj.iterate_rnn(
+            batch_size=batch_size,
+            num_epi_per_seq=num_epi_per_seq,
+            epoch=epoch)
         for batch in iterator:
             pol_loss = ppo_clip.update_pol(
                 pol, optim_pol, batch, clip_param, pol_ent_beta, max_grad_norm)
@@ -78,9 +84,12 @@ def train(agent_traj, expert_traj, pol, vf,
         new_kl_beta = 0
         kl_mean = 0
     elif rl_type == 'ppo_kl':
-        iterator = agent_traj.iterate(batch_size, epoch) if not pol.rnn else agent_traj.iterate_rnn(batch_size=batch_size,
-                                                                                                    num_epi_per_seq=num_epi_per_seq,
-                                                                                                    epoch=epoch)
+        iterator = agent_traj.iterate(
+            batch_size,
+            epoch) if not pol.rnn else agent_traj.iterate_rnn(
+            batch_size=batch_size,
+            num_epi_per_seq=num_epi_per_seq,
+            epoch=epoch)
         for batch in iterator:
             pol_loss = ppo_kl.update_pol(
                 pol, optim_pol, batch, kl_beta, max_grad_norm, pol_ent_beta)
@@ -124,4 +133,9 @@ def train(agent_traj, expert_traj, pol, vf,
     if log_enable:
         logger.log("Optimization finished!")
 
-    return dict(PolLoss=pol_losses, VfLoss=vf_losses, DiscrimLoss=discrim_losses, new_kl_beta=new_kl_beta, kl_mean=kl_mean)
+    return dict(
+        PolLoss=pol_losses,
+        VfLoss=vf_losses,
+        DiscrimLoss=discrim_losses,
+        new_kl_beta=new_kl_beta,
+        kl_mean=kl_mean)

--- a/machina/algos/diayn_sac.py
+++ b/machina/algos/diayn_sac.py
@@ -62,9 +62,9 @@ def train(traj,
 
     discrim : SVfunction
         Discriminator.
-    discrim_f :  function 
+    discrim_f :  function
         Feature extractor of discriminator.
-    f_dim :  
+    f_dim :
         The dimention of discrim_f output.
     num_skill : int
         The number of skills.

--- a/machina/algos/gail.py
+++ b/machina/algos/gail.py
@@ -52,18 +52,24 @@ def train(agent_traj, expert_traj, pol, vf, discrim,
                 pol, batch, max_kl=max_kl, num_cg=num_cg, damping=damping, ent_beta=pol_ent_beta)
             pol_losses.append(pol_loss)
 
-        iterator = agent_traj.iterate(batch_size, epoch) if not pol.rnn else agent_traj.iterate_rnn(batch_size=batch_size,
-                                                                                                    num_epi_per_seq=num_epi_per_seq,
-                                                                                                    epoch=epoch)
+        iterator = agent_traj.iterate(
+            batch_size,
+            epoch) if not pol.rnn else agent_traj.iterate_rnn(
+            batch_size=batch_size,
+            num_epi_per_seq=num_epi_per_seq,
+            epoch=epoch)
         for batch in iterator:
             vf_loss = trpo.update_vf(vf, optim_vf, batch)
             vf_losses.append(vf_loss)
         new_kl_beta = 0
         kl_mean = 0
     elif rl_type == 'ppo_clip':
-        iterator = agent_traj.iterate(batch_size, epoch) if not pol.rnn else agent_traj.iterate_rnn(batch_size=batch_size,
-                                                                                                    num_epi_per_seq=num_epi_per_seq,
-                                                                                                    epoch=epoch)
+        iterator = agent_traj.iterate(
+            batch_size,
+            epoch) if not pol.rnn else agent_traj.iterate_rnn(
+            batch_size=batch_size,
+            num_epi_per_seq=num_epi_per_seq,
+            epoch=epoch)
         for batch in iterator:
             pol_loss = ppo_clip.update_pol(
                 pol, optim_pol, batch, clip_param, pol_ent_beta, max_grad_norm)
@@ -75,9 +81,12 @@ def train(agent_traj, expert_traj, pol, vf, discrim,
         new_kl_beta = 0
         kl_mean = 0
     elif rl_type == 'ppo_kl':
-        iterator = agent_traj.iterate(batch_size, epoch) if not pol.rnn else agent_traj.iterate_rnn(batch_size=batch_size,
-                                                                                                    num_epi_per_seq=num_epi_per_seq,
-                                                                                                    epoch=epoch)
+        iterator = agent_traj.iterate(
+            batch_size,
+            epoch) if not pol.rnn else agent_traj.iterate_rnn(
+            batch_size=batch_size,
+            num_epi_per_seq=num_epi_per_seq,
+            epoch=epoch)
         for batch in iterator:
             pol_loss = ppo_kl.update_pol(
                 pol, optim_pol, batch, kl_beta, max_grad_norm, pol_ent_beta)
@@ -121,4 +130,9 @@ def train(agent_traj, expert_traj, pol, vf, discrim,
     if log_enable:
         logger.log("Optimization finished!")
 
-    return dict(PolLoss=pol_losses, VfLoss=vf_losses, DiscrimLoss=discrim_losses, new_kl_beta=new_kl_beta, kl_mean=kl_mean)
+    return dict(
+        PolLoss=pol_losses,
+        VfLoss=vf_losses,
+        DiscrimLoss=discrim_losses,
+        new_kl_beta=new_kl_beta,
+        kl_mean=kl_mean)

--- a/machina/algos/mpc.py
+++ b/machina/algos/mpc.py
@@ -21,7 +21,16 @@ def update_dm(dm, optim_dm, batch, target='next_obs', td=True):
     return dm_loss.detach().cpu().numpy()
 
 
-def train_dm(traj, dyn_model, optim_dm, epoch=60, batch_size=512, target='next_obs', td=True, num_epi_per_seq=1, log_enable=True):
+def train_dm(
+        traj,
+        dyn_model,
+        optim_dm,
+        epoch=60,
+        batch_size=512,
+        target='next_obs',
+        td=True,
+        num_epi_per_seq=1,
+        log_enable=True):
     """
     Train function for dynamics model.
 

--- a/machina/algos/prioritized_ddpg.py
+++ b/machina/algos/prioritized_ddpg.py
@@ -26,7 +26,7 @@ def train(traj,
     for batch, indices in traj.prioritized_random_batch(batch_size, epoch, return_indices=True):
         qf_bellman_loss = lf.bellman(
             qf, targ_qf, targ_pol, batch, gamma, reduction='none')
-        td_loss = torch.sqrt(qf_bellman_loss*2)
+        td_loss = torch.sqrt(qf_bellman_loss * 2)
         qf_bellman_loss = torch.mean(qf_bellman_loss)
         optim_qf.zero_grad()
         qf_bellman_loss.backward()

--- a/machina/algos/r2d2_sac.py
+++ b/machina/algos/r2d2_sac.py
@@ -98,7 +98,7 @@ def train(traj,
         train_length = seq_length - burn_in_length
         for i in range(batch_size):
             start = start_indices[i] + burn_in_length
-            seq_indices = torch.arange(start, start+train_length-1)
+            seq_indices = torch.arange(start, start + train_length - 1)
             traj = tf.update_pris(
                 traj, td_losses[:, i], seq_indices, update_epi_pris=True, seq_length=seq_length)
 

--- a/machina/logger.py
+++ b/machina/logger.py
@@ -29,6 +29,7 @@
 # ==============================================================================
 # This code is taken from rllab which is MIT-licensed
 
+# mypy: ignore-errors
 
 import collections
 from collections import namedtuple
@@ -147,22 +148,22 @@ def _pipe_line_with_colons(colwidths, colaligns):
 
 
 def _mediawiki_row_with_attrs(separator, cell_values, colwidths, colaligns):
-    alignment = {"left":    '',
-                 "right":   'align="right"| ',
-                 "center":  'align="center"| ',
+    alignment = {"left": '',
+                 "right": 'align="right"| ',
+                 "center": 'align="center"| ',
                  "decimal": 'align="right"| '}
     # hard-coded padding _around_ align attribute and value together
     # rather than padding parameter which affects only the value
     values_with_attrs = [' ' + alignment.get(a, '') + c + ' '
                          for c, a in zip(cell_values, colaligns)]
-    colsep = separator*2
+    colsep = separator * 2
     return (separator + colsep.join(values_with_attrs)).rstrip()
 
 
 def _latex_line_begin_tabular(colwidths, colaligns):
     alignment = {"left": "l", "right": "r", "center": "c", "decimal": "r"}
     tabular_columns_fmt = "".join([alignment.get(a, "l") for a in colaligns])
-    return "\\begin{tabular}{" + tabular_columns_fmt + "}\n\hline"
+    return "\\begin{tabular}{" + tabular_columns_fmt + "}\n\\hline"
 
 
 _table_formats = {"simple":
@@ -243,8 +244,8 @@ _table_formats = {"simple":
 tabulate_formats = list(sorted(_table_formats.keys()))
 
 
-_invisible_codes = re.compile("\x1b\[\d*m")  # ANSI color codes
-_invisible_codes_bytes = re.compile(b"\x1b\[\d*m")  # ANSI color codes
+_invisible_codes = re.compile(r"\x1b\[\d*m")  # ANSI color codes
+_invisible_codes_bytes = re.compile(rb"\x1b\[\d*m")  # ANSI color codes
 
 
 def simple_separated_format(separator):
@@ -288,7 +289,7 @@ def _isint(string):
     >>> _isint("123.45")
     False
     """
-    return type(string) is int or \
+    return isinstance(string, int) or \
         (isinstance(string, _binary_type) or isinstance(string, _text_type)) and \
         _isconvertible(int, string)
 
@@ -554,7 +555,7 @@ def _normalize_tabular_data(tabular_data, headers):
             keys = list(tabular_data.keys())
             vals = tabular_data.values  # values matrix doesn't need to be transposed
             names = tabular_data.index
-            rows = [[v]+list(row) for v, row in zip(names, vals)]
+            rows = [[v] + list(row) for v, row in zip(names, vals)]
         else:
             raise ValueError(
                 "tabular data doesn't appear to be a dict or a DataFrame")
@@ -591,7 +592,7 @@ def _normalize_tabular_data(tabular_data, headers):
         nhs = len(headers)
         ncols = len(rows[0])
         if nhs < ncols:
-            headers = [""]*(ncols - nhs) + headers
+            headers = [""] * (ncols - nhs) + headers
 
     return rows, headers
 
@@ -815,7 +816,7 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
 
     # align columns
     aligns = [numalign if ct in [int, float] else stralign for ct in coltypes]
-    minwidths = [width_fn(h)+2 for h in headers] if headers else [0]*len(cols)
+    minwidths = [width_fn(h) + 2 for h in headers] if headers else [0] * len(cols)
     cols = [_align_column(c, a, minw, has_invisible)
             for c, a, minw in zip(cols, aligns, minwidths)]
 
@@ -859,14 +860,14 @@ def _build_line(colwidths, colaligns, linefmt):
     if hasattr(linefmt, "__call__"):
         return linefmt(colwidths, colaligns)
     else:
-        begin, fill, sep,  end = linefmt
-        cells = [fill*w for w in colwidths]
+        begin, fill, sep, end = linefmt
+        cells = [fill * w for w in colwidths]
         return _build_simple_row(cells, (begin, sep, end))
 
 
 def _pad_row(cells, padding):
     if cells:
-        pad = " "*padding
+        pad = " " * padding
         padded_cells = [pad + cell + pad for cell in cells]
         return padded_cells
     else:
@@ -880,7 +881,7 @@ def _format_table(fmt, headers, rows, colwidths, colaligns):
     pad = fmt.padding
     headerrow = fmt.headerrow
 
-    padded_widths = [(w + 2*pad) for w in colwidths]
+    padded_widths = [(w + 2 * pad) for w in colwidths]
     padded_headers = _pad_row(headers, pad)
     padded_rows = [_pad_row(row, pad) for row in rows]
 
@@ -1154,7 +1155,7 @@ def tweakfun(fun, alt=None):
     args = collect_args()
     if cmd_prefix in args:
         fun = pydoc.locate(args[cmd_prefix])
-    if type(fun) == type:
+    if isinstance(fun, type):
         argspec = inspect.getargspec(fun.__init__)
     else:
         argspec = inspect.getargspec(fun)
@@ -1163,7 +1164,7 @@ def tweakfun(fun, alt=None):
         list(zip(argspec.args[-len(argspec.defaults or []):], argspec.defaults or [])))
     replaced_kwargs = {}
     cmd_prefix += '-'
-    if type(fun) == type:
+    if isinstance(fun, type):
         meta = getattr(fun.__init__, '__tweak_type_hint_meta__', {})
     else:
         meta = getattr(fun, '__tweak_type_hint_meta__', {})
@@ -1552,7 +1553,7 @@ def stub_to_json(stub_sth):
         return {stub_to_json(k): stub_to_json(v) for k, v in stub_sth.items()}
     elif isinstance(stub_sth, (list, tuple)):
         return list(map(stub_to_json, stub_sth))
-    elif type(stub_sth) == type(lambda: None):
+    elif isinstance(stub_sth, type(lambda: None)):
         if stub_sth.__module__ is not None:
             return stub_sth.__module__ + "." + stub_sth.__name__
         return stub_sth.__name__

--- a/machina/pds/deterministic_pd.py
+++ b/machina/pds/deterministic_pd.py
@@ -24,7 +24,15 @@ class DeterministicPd(BasePd):
     def kl_pq(self, p_params, q_params):
         p_mean = p_params['mean']
         q_mean = q_params['mean']
-        return torch.sum(kl_divergence(Normal(loc=p_mean, scale=torch.zeros_like(p_mean)), Normal(loc=q_mean, scale=torch.zeros_like(q_mean))), dim=-1)
+        return torch.sum(
+            kl_divergence(
+                Normal(
+                    loc=p_mean,
+                    scale=torch.zeros_like(p_mean)),
+                Normal(
+                    loc=q_mean,
+                    scale=torch.zeros_like(q_mean))),
+            dim=-1)
 
     def ent(self, params):
         mean = params['mean']

--- a/machina/prepro/base.py
+++ b/machina/prepro/base.py
@@ -24,9 +24,9 @@ class BasePrePro(object):
         """
         Updating running mean and running variance.
         """
-        self.ob_rm = self.ob_rm * (1-self.alpha) + self.alpha * ob
-        self.ob_rv = self.ob_rv * (1-self.alpha) + \
-            self.alpha * np.square(ob-self.ob_rm)
+        self.ob_rm = self.ob_rm * (1 - self.alpha) + self.alpha * ob
+        self.ob_rv = self.ob_rv * (1 - self.alpha) + \
+            self.alpha * np.square(ob - self.ob_rm)
 
     def prepro(self, ob):
         """

--- a/machina/samplers/epi_sampler.py
+++ b/machina/samplers/epi_sampler.py
@@ -88,7 +88,19 @@ def one_epi(env, pol, deterministic=False, prepro=None):
         )
 
 
-def mp_sample(pol, env, max_steps, max_epis, n_steps_global, n_epis_global, epis, exec_flag, deterministic_flag, process_id, prepro=None, seed=256):
+def mp_sample(
+        pol,
+        env,
+        max_steps,
+        max_epis,
+        n_steps_global,
+        n_epis_global,
+        epis,
+        exec_flag,
+        deterministic_flag,
+        process_id,
+        prepro=None,
+        seed=256):
     """
     Multiprocess sample.
     Sampling episodes until max_steps or max_epis is achieved.
@@ -166,8 +178,21 @@ class EpiSampler(object):
         self.epis = mp.Manager().list()
         self.processes = []
         for ind in range(self.num_parallel):
-            p = mp.Process(target=mp_sample, args=(self.pol, env, self.max_steps, self.max_epis, self.n_steps_global,
-                                                   self.n_epis_global, self.epis, self.exec_flags[ind], self.deterministic_flag, ind, prepro, seed))
+            p = mp.Process(
+                target=mp_sample,
+                args=(
+                    self.pol,
+                    env,
+                    self.max_steps,
+                    self.max_epis,
+                    self.n_steps_global,
+                    self.n_epis_global,
+                    self.epis,
+                    self.exec_flags[ind],
+                    self.deterministic_flag,
+                    ind,
+                    prepro,
+                    seed))
             p.start()
             self.processes.append(p)
 

--- a/machina/traj/epi_functional.py
+++ b/machina/traj/epi_functional.py
@@ -71,7 +71,18 @@ def set_all_pris(data, pri):
     return data
 
 
-def compute_pris(data, qf, targ_qf, pol, gamma, continuous=True, deterministic=True, rnn=False, sampling=1, alpha=0.6, epsilon=1e-6):
+def compute_pris(
+        data,
+        qf,
+        targ_qf,
+        pol,
+        gamma,
+        continuous=True,
+        deterministic=True,
+        rnn=False,
+        sampling=1,
+        alpha=0.6,
+        epsilon=1e-6):
     """
     Compute prioritization.
 
@@ -114,7 +125,7 @@ def compute_pris(data, qf, targ_qf, pol, gamma, continuous=True, deterministic=T
             with torch.no_grad():
                 bellman_loss = lf.bellman(
                     qf, targ_qf, pol, data_map, gamma, continuous, deterministic, sampling, reduction='none')
-                td_loss = torch.sqrt(bellman_loss*2)
+                td_loss = torch.sqrt(bellman_loss * 2)
                 pris = (torch.abs(td_loss) + epsilon) ** alpha
                 epi['pris'] = pris.cpu().numpy()
         return data
@@ -147,8 +158,8 @@ def compute_seq_pris(data, seq_length, eta=0.9):
     for epi in epis:
         n_seq = len(epi['pris']) - seq_length + 1
         abs_pris = np.abs(epi['pris'])
-        seq_pris = np.array([eta * np.max(abs_pris[i:i+seq_length]) + (1 - eta) *
-                             np.mean(abs_pris[i:i+seq_length]) for i in range(n_seq)], dtype='float32')
+        seq_pris = np.array([eta * np.max(abs_pris[i:i + seq_length]) + (1 - eta) *
+                             np.mean(abs_pris[i:i + seq_length]) for i in range(n_seq)], dtype='float32')
         pad = np.zeros((seq_length - 1,), dtype='float32')
         epi['seq_pris'] = np.concatenate([seq_pris, pad])
 
@@ -229,7 +240,7 @@ def compute_hs(data, func, hs_name='hs', input_acs=False):
     Parameters
     ----------
     data : Traj or epis(dict of ndarray)
-    func : 
+    func :
         Any function. for example pols, vf and qf.
 
     Returns
@@ -251,10 +262,10 @@ def compute_hs(data, func, hs_name='hs', input_acs=False):
             if input_acs:
                 acs = torch.tensor(
                     epi['acs'], dtype=torch.float, device=get_device()).unsqueeze(1)
-                hs_seq = [func(obs[i:i+1], acs[i:i+1])[-1]['hs']
+                hs_seq = [func(obs[i:i + 1], acs[i:i + 1])[-1]['hs']
                           for i in range(time_seq)]
             else:
-                hs_seq = [func(obs[i:i+1])[-1]['hs'] for i in range(time_seq)]
+                hs_seq = [func(obs[i:i + 1])[-1]['hs'] for i in range(time_seq)]
             if isinstance(hs_seq[0], tuple):
                 hs = np.array([[h.squeeze().detach().cpu().numpy()
                                 for h in hs] for hs in hs_seq], dtype='float32')
@@ -389,7 +400,14 @@ def train_test_split(epis, train_size):
     return train_epis, test_epis
 
 
-def normalize_obs_and_acs(data, mean_obs=None, std_obs=None, mean_acs=None, std_acs=None, return_statistic=True, eps=1e-6):
+def normalize_obs_and_acs(
+        data,
+        mean_obs=None,
+        std_obs=None,
+        mean_acs=None,
+        std_acs=None,
+        return_statistic=True,
+        eps=1e-6):
     with torch.no_grad():
         if isinstance(data, Traj):
             epis = data.current_epis

--- a/machina/traj/traj_functional.py
+++ b/machina/traj/traj_functional.py
@@ -86,15 +86,15 @@ def update_pris(traj, td_loss, indices, alpha=0.6, epsilon=1e-6, update_epi_pris
         seq_start = indices[0]
         for i in range(1, len(traj._epis_index)):
             if seq_start < traj._epis_index[i]:
-                epi_start = traj._epis_index[i-1]
+                epi_start = traj._epis_index[i - 1]
                 epi_end = traj._epis_index[i]
                 break
 
         pris = traj.data_map['pris'][epi_start: epi_end]
         n_seq = len(pris) - seq_length + 1
         abs_pris = np.abs(pris.cpu().numpy())
-        seq_pris = np.array([eta * np.max(abs_pris[i:i+seq_length]) + (1 - eta) *
-                             np.mean(abs_pris[i:i+seq_length]) for i in range(n_seq)], dtype='float32')
+        seq_pris = np.array([eta * np.max(abs_pris[i:i + seq_length]) + (1 - eta) *
+                             np.mean(abs_pris[i:i + seq_length]) for i in range(n_seq)], dtype='float32')
         traj.data_map['seq_pris'][epi_start:epi_start +
                                   n_seq] = torch.tensor(seq_pris, dtype=torch.float, device=get_device())
 

--- a/machina/utils.py
+++ b/machina/utils.py
@@ -36,7 +36,7 @@ def get_redis():
 def _int(v):
     try:
         new_v = int(v)
-    except:
+    except BaseException:
         new_v = -1
     return new_v
 

--- a/tests/env.py
+++ b/tests/env.py
@@ -47,11 +47,11 @@ class PendulumDictEnv(gym.Env):
 
         u = np.clip(u, -self.max_torque, self.max_torque)[0]
         self.last_u = u  # for rendering
-        costs = angle_normalize(th)**2 + .1*thdot**2 + .001*(u**2)
+        costs = angle_normalize(th)**2 + .1 * thdot**2 + .001 * (u**2)
 
         newthdot = thdot + \
-            (-3*g/(2*l) * np.sin(th + np.pi) + 3./(m*l**2)*u) * dt
-        newth = th + newthdot*dt
+            (-3 * g / (2 * l) * np.sin(th + np.pi) + 3. / (m * l**2) * u) * dt
+        newth = th + newthdot * dt
         newthdot = np.clip(newthdot, -self.max_speed,
                            self.max_speed)  # pylint: disable=E1111
 
@@ -91,9 +91,9 @@ class PendulumDictEnv(gym.Env):
             self.img.add_attr(self.imgtrans)
 
         self.viewer.add_onetime(self.img)
-        self.pole_transform.set_rotation(self.state[0] + np.pi/2)
+        self.pole_transform.set_rotation(self.state[0] + np.pi / 2)
         if self.last_u:
-            self.imgtrans.scale = (-self.last_u/2, np.abs(self.last_u)/2)
+            self.imgtrans.scale = (-self.last_u / 2, np.abs(self.last_u) / 2)
 
         return self.viewer.render(return_rgb_array=mode == 'rgb_array')
 
@@ -104,4 +104,4 @@ class PendulumDictEnv(gym.Env):
 
 
 def angle_normalize(x):
-    return (((x+np.pi) % (2*np.pi)) - np.pi)
+    return (((x + np.pi) % (2 * np.pi)) - np.pi)

--- a/tests/sampler/test_sampler.py
+++ b/tests/sampler/test_sampler.py
@@ -32,8 +32,17 @@ class TestTraj(unittest.TestCase):
 
     def test_distributed_epi_sampler(self):
         proc_redis = subprocess.Popen(['redis-server'])
-        proc_slave = subprocess.Popen(['python', '-m', 'machina.samplers.distributed_epi_sampler',
-                                       '--world_size', '1', '--rank', '0', '--redis_host', 'localhost', '--redis_port', '6379'])
+        proc_slave = subprocess.Popen(['python',
+                                       '-m',
+                                       'machina.samplers.distributed_epi_sampler',
+                                       '--world_size',
+                                       '1',
+                                       '--rank',
+                                       '0',
+                                       '--redis_host',
+                                       'localhost',
+                                       '--redis_port',
+                                       '6379'])
         make_redis('localhost', '6379')
         sampler = DistributedEpiSampler(
             1, -1, self.env, self.pol, num_parallel=1)

--- a/tests/simple_net.py
+++ b/tests/simple_net.py
@@ -46,7 +46,7 @@ class PolNet(nn.Module):
             self.mean_layer = nn.Linear(h2, action_space.shape[0])
             if not self.deterministic:
                 self.log_std_param = nn.Parameter(
-                    torch.randn(action_space.shape[0])*1e-10 - 1)
+                    torch.randn(action_space.shape[0]) * 1e-10 - 1)
             self.mean_layer.apply(mini_weight_init)
         else:
             if self.multi:
@@ -144,7 +144,7 @@ class PolNetLSTM(nn.Module):
         if not self.discrete:
             self.mean_layer = nn.Linear(self.cell_size, action_space.shape[0])
             self.log_std_param = nn.Parameter(
-                torch.randn(action_space.shape[0])*1e-10 - 1)
+                torch.randn(action_space.shape[0]) * 1e-10 - 1)
 
             self.mean_layer.apply(mini_weight_init)
         else:
@@ -182,7 +182,8 @@ class PolNetLSTM(nn.Module):
             return means, log_std, hs
         else:
             if self.multi:
-                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2) for ol in self.output_layers], dim=-2), hs
+                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2)
+                                  for ol in self.output_layers], dim=-2), hs
             else:
                 return torch.softmax(self.output_layer(hiddens), dim=-1), hs
 
@@ -357,7 +358,7 @@ class PolDictNet(nn.Module):
             self.mean_layer = nn.Linear(h2, action_space.shape[0])
             if not self.deterministic:
                 self.log_std_param = nn.Parameter(
-                    torch.randn(action_space.shape[0])*1e-10 - 1)
+                    torch.randn(action_space.shape[0]) * 1e-10 - 1)
             self.mean_layer.apply(mini_weight_init)
         else:
             if self.multi:
@@ -411,7 +412,7 @@ class PolNetDictLSTM(nn.Module):
         if not self.discrete:
             self.mean_layer = nn.Linear(self.cell_size, action_space.shape[0])
             self.log_std_param = nn.Parameter(
-                torch.randn(action_space.shape[0])*1e-10 - 1)
+                torch.randn(action_space.shape[0]) * 1e-10 - 1)
 
             self.mean_layer.apply(mini_weight_init)
         else:
@@ -453,6 +454,7 @@ class PolNetDictLSTM(nn.Module):
             return means, log_std, hs
         else:
             if self.multi:
-                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2) for ol in self.output_layers], dim=-2), hs
+                return torch.cat([torch.softmax(ol(hiddens), dim=-1).unsqueeze(-2)
+                                  for ol in self.output_layers], dim=-2), hs
             else:
                 return torch.softmax(self.output_layer(hiddens), dim=-1), hs

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -5,7 +5,6 @@ Test script for algorithms.
 import unittest
 import os
 
-import os
 import pickle
 import numpy as np
 import torch
@@ -17,7 +16,8 @@ import machina as mc
 from machina.pols import GaussianPol, CategoricalPol, MultiCategoricalPol
 from machina.pols import DeterministicActionNoisePol, ArgmaxQfPol, MPCPol, RandomPol
 from machina.noise import OUActionNoise
-from machina.algos import ppo_clip, ppo_kl, trpo, ddpg, sac, svg, qtopt, on_pol_teacher_distill, behavior_clone, gail, airl, mpc, r2d2_sac, diayn, diayn_sac
+from machina.algos import ppo_clip, ppo_kl, trpo, ddpg, sac, svg, qtopt, on_pol_teacher_distill, behavior_clone
+from machina.algos import gail, airl, mpc, r2d2_sac, diayn, diayn_sac
 from machina.vfuncs import DeterministicSVfunc, DeterministicSAVfunc, CEMDeterministicSAVfunc
 from machina.models import DeterministicSModel
 from machina.envs import GymEnv, C2DEnv, SkillEnv
@@ -468,9 +468,14 @@ class TestQTOPT(unittest.TestCase):
             self.env.observation_space, self.env.action_space, qf_net)
         lagged_qf = DeterministicSAVfunc(
             self.env.observation_space, self.env.action_space, lagged_qf_net)
-        targ_qf1 = CEMDeterministicSAVfunc(self.env.observation_space, self.env.action_space, targ_qf1_net, num_sampling=60,
-                                           num_best_sampling=6, num_iter=2,
-                                           multivari=False)
+        targ_qf1 = CEMDeterministicSAVfunc(
+            self.env.observation_space,
+            self.env.action_space,
+            targ_qf1_net,
+            num_sampling=60,
+            num_best_sampling=6,
+            num_iter=2,
+            multivari=False)
         targ_qf2 = DeterministicSAVfunc(
             self.env.observation_space, self.env.action_space, targ_qf2_net)
 

--- a/tests/test_cloud_pickle.py
+++ b/tests/test_cloud_pickle.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import cloudpickle
+import torch
 
 from machina.traj import Traj
 from machina.envs import GymEnv, C2DEnv
@@ -18,7 +19,7 @@ def rew_func(next_obs, acs, mean_obs=0., std_obs=1., mean_acs=0., std_acs=1.):
     acs = acs * std_acs + mean_acs
     # Pendulum
     rews = -(torch.acos(next_obs[:, 0].clamp(min=-1, max=1))**2 +
-             0.1*(next_obs[:, 2].clamp(min=-8, max=8)**2) + 0.001 * acs.squeeze(-1)**2)
+             0.1 * (next_obs[:, 2].clamp(min=-8, max=8)**2) + 0.001 * acs.squeeze(-1)**2)
     rews = rews.squeeze(0)
 
     return rews
@@ -30,8 +31,8 @@ class TestCloudPickle(unittest.TestCase):
     def setUpClass(cls):
         env = GymEnv('Pendulum-v0')
         random_pol = RandomPol(cls.env.observation_space, cls.env.action_space)
-        sampler = EpiSampler(cls.env, pol, num_parallel=1)
-        epis = sampler.sample(pol, max_steps=32)
+        sampler = EpiSampler(cls.env, random_pol, num_parallel=1)
+        epis = sampler.sample(random_pol, max_steps=32)
         traj = Traj()
         traj.add_epis(epis)
         traj.register_epis()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -89,7 +89,7 @@ class TestFlatten2DictPP0(unittest.TestCase):
         traj = ef.compute_h_masks(traj)
         traj.register_epis()
 
-        result_dict = ppo_clip.train(traj=traj, pol=pol, vf=vf, clip_param=0.2,
+        result_dict = ppo_clip.train(traj=traj, pol=pol, vf=vf, clip_param=0.2,  # noqa: F841
                                      optim_pol=optim_pol, optim_vf=optim_vf, epoch=1, batch_size=32)
 
         del sampler
@@ -247,9 +247,9 @@ class TestFlatten2DictR2D2SAC(unittest.TestCase):
         traj = ef.compute_h_masks(traj)
         for i in range(len(qfs)):
             traj = ef.compute_hs(
-                traj, qfs[i], hs_name='q_hs'+str(i), input_acs=True)
+                traj, qfs[i], hs_name='q_hs' + str(i), input_acs=True)
             traj = ef.compute_hs(
-                traj, targ_qfs[i], hs_name='targ_q_hs'+str(i), input_acs=True)
+                traj, targ_qfs[i], hs_name='targ_q_hs' + str(i), input_acs=True)
         traj.register_epis()
 
         result_dict = r2d2_sac.train(


### PR DESCRIPTION
This PR introduces flake8 in CI. 
Note that `.flake8` config file also affects autopep8. I found that some files were not formatted by autopep8 previously for some reason, but introducing `.flake8` files solved it.
I did aggressive formatting (`autopep8 --aggressive --aggressive -r .`) to fix some flake8 warnings.

See [this](https://lintlyci.github.io/Flake8Rules/) for flake8 warning information.