### PR TITLE
Fix contributing.md typo. Tracis-CI -> Travis-CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,4 @@ Kullback-Leibler -> kl
 ```
 
 # Test
-We use Tracis-CI for testing code in machina. Please check if the status of the tests is shown as passing.
+We use Travis-CI for testing code in machina. Please check if the status of the tests is shown as passing.


### PR DESCRIPTION
Fixing typo inside the CONTRIBUTING.md file.

Tracis-CI should be Travis-CI